### PR TITLE
Potential fix for code scanning alert no. 2: Unsafe jQuery plugin

### DIFF
--- a/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -1069,7 +1069,7 @@ $.extend( $.validator, {
 			}
 
 			// Always apply ignore filter
-			return $( element ).not( this.settings.ignore )[ 0 ];
+			return $( this.escapeCssMeta(element) ).not( this.settings.ignore )[ 0 ];
 		},
 
 		checkable: function( element ) {


### PR DESCRIPTION
Potential fix for [https://github.com/Khyarus/PortifolioCSH/security/code-scanning/2](https://github.com/Khyarus/PortifolioCSH/security/code-scanning/2)

To fix the problem, we need to ensure that any user-controlled input used in jQuery selectors is properly sanitized to prevent XSS vulnerabilities. Specifically, we should use the `escapeCssMeta` function to sanitize the `element` variable before it is used in the jQuery selector on line 1072.

- Modify the `validationTargetFor` function to sanitize the `element` variable using the `escapeCssMeta` function.
- Ensure that the `element` variable is properly escaped before being used in the jQuery selector.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
