### PR TITLE
Potential fix for code scanning alert no. 1: Unsafe jQuery plugin

### DIFF
--- a/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -684,7 +684,7 @@ $.extend( $.validator, {
 		},
 
 		clean: function( selector ) {
-			return $( selector )[ 0 ];
+			return this.currentForm ? $( this.currentForm ).find( selector )[ 0 ] : null;
 		},
 
 		errors: function() {


### PR DESCRIPTION
Potential fix for [https://github.com/Khyarus/PortifolioCSH/security/code-scanning/1](https://github.com/Khyarus/PortifolioCSH/security/code-scanning/1)

To fix the problem, we need to ensure that the `selector` parameter is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of directly passing the `selector` to the jQuery function. The `jQuery.find` method interprets the input as a CSS selector, which mitigates the risk of XSS.

- Modify the `clean` function to use `jQuery.find` instead of `jQuery`.
- Ensure that the `selector` parameter is properly sanitized and validated as a CSS selector.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
